### PR TITLE
fix(frontend/src/components/pages/Filter/

### DIFF
--- a/frontend/src/components/pages/Filter/FilterCmd.jsx
+++ b/frontend/src/components/pages/Filter/FilterCmd.jsx
@@ -79,7 +79,7 @@ export const FilterCmd = () => {
                     />
                   </span>
                   <div className="buttons-container">
-                  <CopyButton textToCopy={command.command} className="copy-button" />
+                  <CopyButton textToCopy={command.text} className="copy-button" />
                   <UpdateButton className="update-button"
                     disabled={currentText === command.text}
                     handle={() =>


### PR DESCRIPTION
This pull request includes a small change to the `FilterCmd` component in `FilterCmd.jsx`. The change updates the `textToCopy` prop of the `CopyButton` component to use `command.text` instead of `command.command`./FilterCmd.jsx): Field for accurate copy content


