### PR TITLE
Improve Sileo toast header and badge alignment styles

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,6 +24,22 @@
   color: #ffffff !important;
 }
 
+.sileo-badge-fix {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+[data-sileo-header] {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+[data-sileo-title] {
+  line-height: var(--sileo-height);
+}
+
 body {
   background-color: var(--bg-primary);
   color: var(--text-primary);


### PR DESCRIPTION
- Add .sileo-badge-fix CSS to center badge content

- Style [data-sileo-header] with flex, align-items: center, and box-sizing: border-box

- Set [data-sileo-title] line-height to var(--sileo-height) for vertical alignment