### PR TITLE
Process OAuth tokens from query params and set CSRF token

### DIFF
--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Navbar } from './layout/Navbar';
-import { Route, Routes, useLocation, Navigate } from 'react-router-dom';
+import { Route, Routes, useLocation, Navigate, useNavigate } from 'react-router-dom';
 
 function NavigateWithQuery({ to }) {
   const location = useLocation();
@@ -15,6 +15,7 @@ import { TrialProvider, useTrial } from '../shared/context/TrialContext';
 import { AuthProvider, useAuth } from '../shared/context/AuthContext';
 import { TrialModal } from '../shared/ui/Modal/TrialModal';
 import { Toaster, sileo } from 'sileo';
+import { setCsrfToken } from '../shared/api/apiClient';
 
 function AppContentInner() {
   const [terminalInput, setTerminalInput] = useState('');
@@ -28,7 +29,6 @@ function AppContentInner() {
     }
   });
   const [isProcessing, setIsProcessing] = useState(false);
-  const { isAuthenticated, loading } = useAuth();
   const [commandHistory, setCommandHistory] = useState(() => {
     try {
       const savedHistory = localStorage.getItem('commander_command_history');
@@ -40,7 +40,24 @@ function AppContentInner() {
   });
 
   const currentLocation = useLocation();
+  const navigate = useNavigate();
+  const { isAuthenticated, loading, login } = useAuth();
   const { getTrialCommand } = useTrial();
+
+  useEffect(() => {
+    const params = new URLSearchParams(currentLocation.search);
+    const accessToken = params.get('accessToken');
+    const csrfToken = params.get('csrfToken');
+    const userId = params.get('userId');
+    const username = params.get('username');
+    const email = params.get('email');
+
+    if (accessToken && userId) {
+      if (csrfToken) setCsrfToken(csrfToken);
+      login({ accessToken, userId, username, email });
+      navigate('/terminal', { replace: true });
+    }
+  }, []);
 
   useEffect(() => {
     localStorage.setItem(


### PR DESCRIPTION
This pull request updates the authentication flow in the `App.jsx` file to support login via URL query parameters, streamlining the process for users who arrive with authentication tokens in the URL. It also introduces a utility to set the CSRF token when provided.

**Authentication and login improvements:**

* Added logic in `AppContentInner` to extract `accessToken`, `csrfToken`, `userId`, `username`, and `email` from the URL query parameters. If `accessToken` and `userId` are present, the app logs in the user and navigates to `/terminal`. (`frontend/src/app/App.jsx`)
* Integrated the `setCsrfToken` utility to store the CSRF token from the URL if available, enhancing security for subsequent API requests. (`frontend/src/app/App.jsx`)

**Code enhancements:**

* Updated imports to include `useNavigate` for programmatic navigation and `setCsrfToken` for CSRF handling. (`frontend/src/app/App.jsx`) [[1]](diffhunk://#diff-9a55b6b261abb92408c41f027eda047edc8db93e8952b99e5e9e8f73f9de89c6L3-R3) [[2]](diffhunk://#diff-9a55b6b261abb92408c41f027eda047edc8db93e8952b99e5e9e8f73f9de89c6R18)
* Refactored the `useAuth` hook usage to include the `login` method, enabling authentication through the new URL-based flow. (`frontend/src/app/App.jsx`)